### PR TITLE
Fix build type errors

### DIFF
--- a/packages/backend/tests/getLogsWithPaginationTest.ts
+++ b/packages/backend/tests/getLogsWithPaginationTest.ts
@@ -79,8 +79,9 @@ async function testPagination(): Promise<void> {
   assert.equal(provider.sendCalls.length, 2, "should call alchemy_getLogs twice");
   const firstCall = provider.sendCalls[0];
   assert.equal(firstCall.method, "alchemy_getLogs");
-  assert.equal(firstCall.params[0].fromBlock, ethers.toBeHex(23048076));
-  assert.equal(firstCall.params[0].toBlock, ethers.toBeHex(23048080));
+  const params0 = firstCall.params[0] as { fromBlock: string; toBlock: string };
+  assert.equal(params0.fromBlock, ethers.toBeHex(23048076));
+  assert.equal(params0.toBlock, ethers.toBeHex(23048080));
 }
 
 async function testFallback(): Promise<void> {


### PR DESCRIPTION
Resolve TypeScript build errors by improving type safety for feed item properties and test parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c910525-a0a9-49ec-88e3-079124857a99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c910525-a0a9-49ec-88e3-079124857a99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve type safety in feed parsing (guid/author) and update pagination test assertions for typed params.
> 
> - **Backend**:
>   - **Feed parsing (`packages/backend/shared/feedPreview.ts`)**:
>     - Safely derive `guid` using a typed candidate list and string type guard.
>     - Type-safe `author` extraction by checking `creator`/`author` as strings.
>   - **Tests (`packages/backend/tests/getLogsWithPaginationTest.ts`)**:
>     - Cast `firstCall.params[0]` to a typed object before asserting `fromBlock`/`toBlock` hex values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ccc11a0e8e6a0762cf49777debdb0d1300a8625. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->